### PR TITLE
Code clean up 181210

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,36 +13,19 @@ import SettingsMenu from "./components/SettingsMenu/SettingsMenu";
 import "./App.css";
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-
-    // this.logout = this.logout.bind(this);
-    // this.checkLogin = this.checkLogin.bind(this);
+  constructor() {
+    super();
   }
 
   componentDidMount() {
     console.log("this is my token if it exists: " + localStorage.getItem("token"));
-    // this.checkLogin();
-    if(localStorage.getItem("item") !== '')
+    if(localStorage.getItem("item") !== null)
     {
       this.props.checkLogin(localStorage.getItem("token"));
     } 
-  }
-
-  // checkLogin = () => {
-  //   if (localStorage.getItem("state") === null) {
-  //     this.props.checkLogin("");
-  //   } else this.props.checkLogin(this.props.token, this.props.id);
-  // };
-
-  // logout = event => {
-  //   event.preventDefault();
-  //   localStorage.removeItem("state");
-  //   this.props.logout();
-  // };
+  };
 
   render() {
-    // const { loggedIn, token, id } = this.props;
     if (this.props.loggedIn) {
       return (
         <div className="App">
@@ -77,15 +60,3 @@ export default connect(
   matchDispatchToProps
 )(App);
 
-// <Header />
-// <Carousel />
-// <div className="loginBox">
-//   <button id="sign-up-button"
-//     onClick={this.changeForm}
-//     className="btn btn-primary">
-//     Sign-Up
-//   </button>
-//   <button id="login-button" onClick={this.changeForm} className="btn btn-primary">Login</button>
-//   <LoginForm buttonClick={this.buttonClick} loginForm={this.state.accountCreated} />
-// </div>
-// <Footer />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -48,6 +48,7 @@ class App extends Component {
   // };
 
   render() {
+    console.log(this.props.loggedIn);
     if (this.props.loggedIn) {
       return (
         <div className="App">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,40 +16,42 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    this.logout = this.logout.bind(this);
-    this.checkLogin = this.checkLogin.bind(this);
+    // this.logout = this.logout.bind(this);
+    // this.checkLogin = this.checkLogin.bind(this);
   }
 
   componentDidMount() {
-    this.checkLogin();
+    console.log("this is my token if it exists: " + localStorage.getItem("token"));
+    // this.checkLogin();
+    this.props.checkLogin();
   }
 
-  checkLogin = () => {
-    if (localStorage.getItem("state") === null) {
-      this.props.checkLogin("");
-    } else this.props.checkLogin(this.props.token, this.props.id);
-  };
+  // checkLogin = () => {
+  //   if (localStorage.getItem("state") === null) {
+  //     this.props.checkLogin("");
+  //   } else this.props.checkLogin(this.props.token, this.props.id);
+  // };
 
-  logout = event => {
-    event.preventDefault();
-
-    localStorage.removeItem("state");
-    this.props.logout();
-  };
+  // logout = event => {
+  //   event.preventDefault();
+  //   localStorage.removeItem("state");
+  //   this.props.logout();
+  // };
 
   render() {
-    if (this.props.token !== "") {
+    const { token, id } = this.props;
+    if (token !== "") {
       return (
         <div className="App">
-          <SettingsMenu logout={this.logout} />
-          <AdminPanel token={this.props.token} />
+          <SettingsMenu />
+          <AdminPanel />
         </div>
       );
     } else {
       return (
         <div className="App">
           <Header />
-          <Login checkLogin={this.checkLogin} />
+          <Login />
           <Footer />
         </div>
       );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -23,7 +23,10 @@ class App extends Component {
   componentDidMount() {
     console.log("this is my token if it exists: " + localStorage.getItem("token"));
     // this.checkLogin();
-    this.props.checkLogin();
+    if(localStorage.getItem("item") !== '')
+    {
+      this.props.checkLogin(localStorage.getItem("token"));
+    } 
   }
 
   // checkLogin = () => {
@@ -39,8 +42,8 @@ class App extends Component {
   // };
 
   render() {
-    const { token, id } = this.props;
-    if (token !== "") {
+    // const { loggedIn, token, id } = this.props;
+    if (this.props.loggedIn) {
       return (
         <div className="App">
           <SettingsMenu />
@@ -60,6 +63,7 @@ class App extends Component {
 }
 
 const mapStateToProps = state => ({
+  loggedIn: state.Login.loggedIn,
   token: state.Login.token,
   id: state.Login.id
 });

--- a/client/src/actions/loginAction.js
+++ b/client/src/actions/loginAction.js
@@ -17,16 +17,18 @@ export function checkLogin(token, id) {
       }
     });
   };
-}
+};
 
-export function login(token) {
+export function login(username, password) {
+  // console.log(username);
+  // console.log(password);
   const settings = {
     method: "POST",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json"
     },
-    body: JSON.stringify(token)
+    body: JSON.stringify({username, password})
   };
 
   return dispatch => {
@@ -43,8 +45,9 @@ export function login(token) {
 }
 
 export function logout() {
+  console.log("user is logging out");
   const settings = {
-    method: "POST",
+    method: "GET",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json"

--- a/client/src/actions/loginAction.js
+++ b/client/src/actions/loginAction.js
@@ -1,4 +1,5 @@
-export function checkLogin(token, id) {
+export function checkLogin(token) {
+  console.log(token);
   const settings = {
     method: "POST",
     headers: {
@@ -13,7 +14,7 @@ export function checkLogin(token, id) {
       if (res.status === 403) {
         dispatch(fetchNotLoggedIn());
       } else {
-        dispatch(fetchLoggedIn(token, id));
+        dispatch(fetchLoggedIn(token));
       }
     });
   };
@@ -35,6 +36,9 @@ export function login(username, password) {
     return fetch("/login", settings)
       .then(res => res.json())
       .then(json => {
+        // console.log(json);
+        localStorage.setItem('token', json.token);
+        localStorage.setItem('id',json.id);
         if (json.success) {
           dispatch(fetchLoginSuccess(json));
           return json;
@@ -46,6 +50,8 @@ export function login(username, password) {
 
 export function logout() {
   console.log("user is logging out");
+  localStorage.removeItem('token');
+  localStorage.removeItem('id');
   const settings = {
     method: "GET",
     headers: {
@@ -59,23 +65,24 @@ export function logout() {
   };
 }
 
-export const fetchLoggedIn = (token, id) => {
+export const fetchLoggedIn = (token) => {
   return {
     type: "LOGGED_IN",
-    payload: { token, id }
+    payload: {token}
   };
 };
 
 export const fetchNotLoggedIn = () => {
   return {
-    type: "NOT_LOGGED_IN"
+    type: "NOT_LOGGED_IN",
+    payload: {loggedIn: false}
   };
 };
 
 export const fetchLoginSuccess = json => {
   return {
     type: "LOGIN_SUCCESS",
-    payload: { json }
+    payload: { loggedIn: true, json }
   };
 };
 

--- a/client/src/actions/loginAction.js
+++ b/client/src/actions/loginAction.js
@@ -68,7 +68,7 @@ export function logout() {
 export const fetchLoggedIn = (token) => {
   return {
     type: "LOGGED_IN",
-    payload: {token}
+    payload: {loggedIn: true, token}
   };
 };
 

--- a/client/src/components/LoginForm/LoginForm.js
+++ b/client/src/components/LoginForm/LoginForm.js
@@ -5,15 +5,12 @@ import { login } from "../../actions/loginAction";
 import "./LoginForm.css";
 
 class LoginForm extends Component {
-  constructor(props) {
-    super(props);
-
-    // this.onClick = this.onClick.bind(this);
-  }
+  constructor() {
+    super();
+  };
 
   onClick = (event) => {
     event.preventDefault();
-    // console.log(this.usernameInput.value);
     this.props.login(this.usernameInput.value, this.passwordInput.value);
   };
 

--- a/client/src/components/LoginForm/LoginForm.js
+++ b/client/src/components/LoginForm/LoginForm.js
@@ -10,6 +10,7 @@ export default class LoginForm extends Component {
   }
 
   onClick = (event) => {
+    event.preventDefault();
     this.props.onClick(this.usernameInput.value, this.passwordInput.value);
   //   event.preventDefault();
   //   console.log(this.usernameInput.value)
@@ -95,6 +96,7 @@ export default class LoginForm extends Component {
             </button>
           </div>
         </form>
+      
       </div>
     );
   }

--- a/client/src/components/LoginForm/LoginForm.js
+++ b/client/src/components/LoginForm/LoginForm.js
@@ -1,17 +1,20 @@
 import React, { Component } from "react";
-
+import { connect } from "react-redux";
+import {bindActionCreators} from 'redux';
+import { login } from "../../actions/loginAction";
 import "./LoginForm.css";
 
-export default class LoginForm extends Component {
+class LoginForm extends Component {
   constructor(props) {
     super(props);
 
-    this.onClick = this.onClick.bind(this);
+    // this.onClick = this.onClick.bind(this);
   }
 
   onClick = (event) => {
     event.preventDefault();
-    this.props.onClick(this.usernameInput.value, this.passwordInput.value);
+    // console.log(this.usernameInput.value);
+    this.props.login(this.usernameInput.value, this.passwordInput.value);
   };
 
   render() {
@@ -68,4 +71,19 @@ export default class LoginForm extends Component {
       </div>
     );
   }
-}
+};
+
+const mapStateToProps = state => ({
+  loggedIn: state.Login.loggedIn,
+  token: state.Login.token,
+  id: state.Login.id,
+});
+
+const matchDispatchToProps = dispatch => {
+  return bindActionCreators({ login }, dispatch);
+};
+
+export default connect(
+  mapStateToProps,
+  matchDispatchToProps
+)(LoginForm);

--- a/client/src/components/SettingsMenu/SettingsMenu.js
+++ b/client/src/components/SettingsMenu/SettingsMenu.js
@@ -5,15 +5,15 @@ import { logout } from "../../actions/loginAction";
 import "./SettingsMenu.css";
 
 class SettingsMenu extends Component {
-  constructor(props) {
-    super(props);
-    // this.state = {};
-  }
+  constructor() {
+    super();
+  };
 
   onClick = (e) => {
     e.preventDefault();
     this.props.logout();
-  }
+  };
+  
   render() {
     return (
       <div className="dropdown">

--- a/client/src/components/SettingsMenu/SettingsMenu.js
+++ b/client/src/components/SettingsMenu/SettingsMenu.js
@@ -1,12 +1,19 @@
 import React, { Component } from "react";
+import { connect } from "react-redux";
+import {bindActionCreators} from 'redux';
+import { logout } from "../../actions/loginAction";
 import "./SettingsMenu.css";
 
-export default class SettingsMenu extends Component {
+class SettingsMenu extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    // this.state = {};
   }
 
+  onClick = (e) => {
+    e.preventDefault();
+    this.props.logout();
+  }
   render() {
     return (
       <div className="dropdown">
@@ -22,10 +29,25 @@ export default class SettingsMenu extends Component {
         </button>
         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="settings-button">
           <li>
-            <a href="/" onClick={this.props.logout}>Logout</a>
+            <a href="/" onClick={this.onClick}>Logout</a>
           </li>
         </ul>
       </div>
     );
   }
-}
+};
+
+const mapStateToProps = state => ({
+  loggedIn: state.Login.loggedIn,
+  token: state.Login.token,
+  id: state.Login.id,
+});
+
+const matchDispatchToProps = dispatch => {
+  return bindActionCreators({ logout }, dispatch);
+};
+
+export default connect(
+  mapStateToProps,
+  matchDispatchToProps
+)(SettingsMenu);

--- a/client/src/containers/Login/Login.js
+++ b/client/src/containers/Login/Login.js
@@ -9,17 +9,17 @@ import logo from "../../images/ParcelMascot.png";
 
 import "./Login.css";
 
-class Login extends Component {
+export default class Login extends Component {
   constructor(props) {
     super(props);
 
-    this.onClick = this.onClick.bind(this);
+    // this.onClick = this.onClick.bind(this);
   }
 
-  onClick = (username, password) => {
-    if (username !== "" && password !== "")
-      this.props.login({ username, password });
-  };
+  // onClick = (username, password) => {
+  //   if (username !== "" && password !== "")
+  //     this.props.login({ username, password });
+  // };
 
   render() {
     return (
@@ -31,7 +31,7 @@ class Login extends Component {
             <img id="logo" src={logo} alt="logo" width="250" height="250" />
           </div>
           <div id="login-box">
-            <LoginForm onClick={this.onClick} />
+            <LoginForm />
             <div className="clearfix">
               <label>Don't have an account?</label>
               <button
@@ -53,16 +53,16 @@ class Login extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  token: state.Login.token,
-  id: state.Login.id,
-});
+// const mapStateToProps = state => ({
+//   token: state.Login.token,
+//   id: state.Login.id,
+// });
 
-const matchDispatchToProps = dispatch => {
-  return bindActionCreators({ login }, dispatch);
-};
+// const matchDispatchToProps = dispatch => {
+//   return bindActionCreators({ login }, dispatch);
+// };
 
-export default connect(
-  mapStateToProps,
-  matchDispatchToProps
-)(Login);
+// export default connect(
+//   mapStateToProps,
+//   matchDispatchToProps
+// )(Login);

--- a/client/src/containers/Login/Login.js
+++ b/client/src/containers/Login/Login.js
@@ -10,17 +10,10 @@ import logo from "../../images/ParcelMascot.png";
 import "./Login.css";
 
 export default class Login extends Component {
-  constructor(props) {
-    super(props);
-
-    // this.onClick = this.onClick.bind(this);
+  constructor() {
+    super();
   }
-
-  // onClick = (username, password) => {
-  //   if (username !== "" && password !== "")
-  //     this.props.login({ username, password });
-  // };
-
+  
   render() {
     return (
       <div>
@@ -52,17 +45,3 @@ export default class Login extends Component {
     );
   }
 }
-
-// const mapStateToProps = state => ({
-//   token: state.Login.token,
-//   id: state.Login.id,
-// });
-
-// const matchDispatchToProps = dispatch => {
-//   return bindActionCreators({ login }, dispatch);
-// };
-
-// export default connect(
-//   mapStateToProps,
-//   matchDispatchToProps
-// )(Login);

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,48 +1,23 @@
-// import React from "react";
-// import ReactDOM from "react-dom";
-// import "./index.css";
-// import App from "./App";
-// // import Test from './Test';
-// // import Friends from './Friends';
-// import * as serviceWorker from "./serviceWorker";
-// import { Provider } from "react-redux";
-// import { createStore, applyMiddleware, compose } from "redux";
-// import thunk from "redux-thunk";
-// import allReducers from "./reducers";
-// //
-//
-// const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-//
-// const store = createStore(
-//   allReducers,
-//   composeEnhancers(applyMiddleware(thunk))
-//   //middleware which we can add to Redux to effectively teach it how to deal with new kinds of actions.
-// );
-//
-// ReactDOM.render(
-//   <Provider store={store}>
-//     <App />
-//   </Provider>,
-//   document.getElementById("root")
-// );
-//
-// // If you want your app to work offline and load faster, you can change
-// // unregister() to register() below. Note this comes with some pitfalls.
-// // Learn more about service workers: http://bit.ly/CRA-PWA
-// serviceWorker.unregister();
-
-
 import React from "react";
 import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+// import Test from './Test';
+// import Friends from './Friends';
 import * as serviceWorker from "./serviceWorker";
 import { Provider } from "react-redux";
-import App from "./App";
+import { createStore, applyMiddleware, compose } from "redux";
+import thunk from "redux-thunk";
+import allReducers from "./reducers";
+//
 
-import configureStore from "./store/configureStore.js";
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-import "./index.css";
-
-const store = configureStore();
+const store = createStore(
+  allReducers,
+  composeEnhancers(applyMiddleware(thunk))
+  //middleware which we can add to Redux to effectively teach it how to deal with new kinds of actions.
+);
 
 ReactDOM.render(
   <Provider store={store}>
@@ -50,6 +25,31 @@ ReactDOM.render(
   </Provider>,
   document.getElementById("root")
 );
+//
+// // If you want your app to work offline and load faster, you can change
+// // unregister() to register() below. Note this comes with some pitfalls.
+// // Learn more about service workers: http://bit.ly/CRA-PWA
+// serviceWorker.unregister();
+
+
+// import React from "react";
+// import ReactDOM from "react-dom";
+// import * as serviceWorker from "./serviceWorker";
+// import { Provider } from "react-redux";
+// import App from "./App";
+
+// import configureStore from "./store/configureStore.js";
+
+// import "./index.css";
+
+// const store = configureStore();
+
+// ReactDOM.render(
+//   <Provider store={store}>
+//     <App />
+//   </Provider>,
+//   document.getElementById("root")
+// );
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/client/src/reducers/reducer-login.js
+++ b/client/src/reducers/reducer-login.js
@@ -1,4 +1,5 @@
 const initialState = {
+  loggedIn: false,
   token: "",
   id: ""
 };
@@ -8,6 +9,7 @@ export default function loginReducer(state = initialState, action) {
     case "LOGGED_IN":
       return {
         ...state,
+        loggedIn: true,
         token: action.payload.token,
         id: action.payload.id,
       };
@@ -20,6 +22,7 @@ export default function loginReducer(state = initialState, action) {
     case "LOGIN_SUCCESS":
       return {
         ...state,
+        loggedIn: true,
         token: action.payload.json.token,
         id: action.payload.json.id,
       };

--- a/client/src/reducers/reducer-login.js
+++ b/client/src/reducers/reducer-login.js
@@ -9,21 +9,21 @@ export default function loginReducer(state = initialState, action) {
     case "LOGGED_IN":
       return {
         ...state,
-        loggedIn: true,
+        loggedIn: action.payload.loggedIn,
         token: action.payload.token,
         id: action.payload.id,
       };
     case "NOT_LOGGED_IN":
       return {
         ...state,
-        loggedIn: false,
+        loggedIn:  action.payload.loggedIn,
         token: "",
         id: ""
       };
     case "LOGIN_SUCCESS":
       return {
         ...state,
-        loggedIn: true,
+        loggedIn: action.payload.loggedIn,
         token: action.payload.json.token,
         id: action.payload.json.id,
       };

--- a/client/src/reducers/reducer-login.js
+++ b/client/src/reducers/reducer-login.js
@@ -16,6 +16,7 @@ export default function loginReducer(state = initialState, action) {
     case "NOT_LOGGED_IN":
       return {
         ...state,
+        loggedIn: false,
         token: "",
         id: ""
       };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -666,6 +666,12 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -731,6 +737,46 @@
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
+
+"@emotion/babel-utils@^0.6.4":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"
+  dependencies:
+    "@emotion/hash" "^0.6.6"
+    "@emotion/memoize" "^0.6.6"
+    "@emotion/serialize" "^0.9.1"
+    convert-source-map "^1.5.1"
+    find-root "^1.1.0"
+    source-map "^0.7.2"
+
+"@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
+
+"@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+
+"@emotion/serialize@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.9.1.tgz#a494982a6920730dba6303eb018220a2b629c145"
+  dependencies:
+    "@emotion/hash" "^0.6.6"
+    "@emotion/memoize" "^0.6.6"
+    "@emotion/unitless" "^0.6.7"
+    "@emotion/utils" "^0.8.2"
+
+"@emotion/stylis@^0.7.0":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
+
+"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
+
+"@emotion/utils@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
 "@svgr/core@^2.4.1":
   version "2.4.1"
@@ -1191,6 +1237,20 @@ autoprefixer@^9.1.5:
     postcss "^7.0.2"
     postcss-value-parser "^3.2.3"
 
+aws-sdk@^2.368.0:
+  version "2.377.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.377.0.tgz#34220a844070c85fa266427128d2f70ddac63c53"
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -1318,6 +1378,23 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-emotion@^9.2.11:
+  version "9.2.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz#319c005a9ee1d15bb447f59fe504c35fd5807728"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/babel-utils" "^0.6.4"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^2.0.1"
+
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -1331,7 +1408,7 @@ babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
-babel-plugin-macros@2.4.2:
+babel-plugin-macros@2.4.2, babel-plugin-macros@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz#21b1a2e82e2130403c5ff785cba6548e9b644b28"
   dependencies:
@@ -1341,6 +1418,10 @@ babel-plugin-macros@2.4.2:
 babel-plugin-named-asset-import@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.2.2.tgz#af1290f77e073411ef1a12f17fc458f1111122eb"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -1668,7 +1749,7 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
-buffer@^4.3.0:
+buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
   resolved "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   dependencies:
@@ -1874,6 +1955,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 clean-css@4.2.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
@@ -2071,7 +2156,7 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
@@ -2131,6 +2216,18 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-emotion@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
+  dependencies:
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    "@emotion/unitless" "^0.6.2"
+    csstype "^2.5.2"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -2360,6 +2457,10 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.5.2:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.8.tgz#4ce5aa16ea0d562ef9105fa3ae2676f199586a35"
 
 cyclist@~0.2.2:
   version "0.2.2"
@@ -2596,6 +2697,12 @@ dom-converter@~0.2:
   dependencies:
     utila "~0.4"
 
+dom-helpers@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -2708,6 +2815,13 @@ emoji-regex@^6.5.1:
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+
+emotion@^9.1.2:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
+  dependencies:
+    babel-plugin-emotion "^9.2.11"
+    create-emotion "^9.2.12"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2962,7 +3076,7 @@ eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
-events@^1.0.0:
+events@1.1.1, events@^1.0.0:
   version "1.1.1"
   resolved "http://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -3272,6 +3386,10 @@ find-cache-dir@^2.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^3.0.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
@@ -3710,6 +3828,12 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
+hoist-non-react-statics@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3875,6 +3999,10 @@ identity-obj-proxy@3.0.0:
   resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
   dependencies:
     harmony-reflect "^1.4.6"
+
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 ieee754@^1.1.4:
   version "1.1.12"
@@ -4662,6 +4790,10 @@ jest@23.6.0:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+
 joi@^11.1.1:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-11.4.0.tgz#f674897537b625e9ac3d0b7e1604c828ad913ccb"
@@ -5010,7 +5142,7 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -5092,6 +5224,10 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
+
+memoize-one@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -5444,6 +5580,12 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -6528,7 +6670,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.6, prop-types@^15.6.2:
+prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6629,6 +6771,12 @@ raf@3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
+raf@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  dependencies:
+    performance-now "^2.1.0"
+
 randomatic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
@@ -6682,6 +6830,10 @@ react-app-polyfill@^0.1.3:
     raf "3.4.0"
     whatwg-fetch "3.0.0"
 
+react-awesome-modal@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-awesome-modal/-/react-awesome-modal-2.0.5.tgz#d19702f7e3bc1f43e734f5a60814c2d1593c693a"
+
 react-dev-utils@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-6.0.4.tgz#cd6d2712aa22d67751ef6757dc82787351da8826"
@@ -6722,6 +6874,20 @@ react-error-overlay@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.4.tgz#39cf184d770f98b65a2ee59a779d03b8d092b69e"
 
+react-input-autosize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
+react-is@^16.3.2, react-is@^16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
 react-player@^1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/react-player/-/react-player-1.6.6.tgz#336de320fc8c0610d8f2292ec16b0056312a1964"
@@ -6729,6 +6895,17 @@ react-player@^1.6.6:
     deepmerge "^2.0.1"
     load-script "^1.0.0"
     prop-types "^15.5.6"
+
+react-redux@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-6.0.0.tgz#09e86eeed5febb98e9442458ad2970c8f1a173ef"
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    hoist-non-react-statics "^3.2.1"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.3"
 
 react-scripts@2.0.4:
   version "2.0.4"
@@ -6782,6 +6959,27 @@ react-scripts@2.0.4:
     workbox-webpack-plugin "3.6.2"
   optionalDependencies:
     fsevents "1.2.4"
+
+react-select@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.1.2.tgz#7a3e4c2b9efcd8c44ae7cf6ebb8b060ef69c513c"
+  dependencies:
+    classnames "^2.2.5"
+    emotion "^9.1.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
+    react-transition-group "^2.2.1"
+
+react-transition-group@^2.2.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.1.tgz#67fbd8d30ebb1c57a149d554dbb82eabefa61f0d"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.5.2:
   version "16.5.2"
@@ -6873,6 +7071,17 @@ reduce-css-calc@^2.0.0:
   dependencies:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+
+redux@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"
@@ -7181,7 +7390,11 @@ sass-loader@7.1.0:
     pify "^3.0.0"
     semver "^5.5.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -7458,6 +7671,10 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+source-map@^0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+
 spdx-correct@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
@@ -7687,6 +7904,14 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -7721,6 +7946,10 @@ svgo@^1.0.0, svgo@^1.0.5:
     stable "~0.1.6"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 symbol-tree@^3.2.2:
   version "3.2.2"
@@ -7866,6 +8095,12 @@ topo@2.x.x:
   resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
   dependencies:
     hoek "4.x.x"
+
+touch@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.4.3, tough-cookie@~2.4.3:
   version "2.4.3"
@@ -8050,6 +8285,13 @@ url-parse@^1.1.8, url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -8091,6 +8333,10 @@ utila@^0.4.0, utila@~0.4:
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+
+uuid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
@@ -8478,6 +8724,17 @@ ws@^6.0.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
 
 xmlchars@^1.3.1:
   version "1.3.1"

--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ app.get('/', function(req, res){
 app.post('/login', function(req,res){
   let username = req.body.username;
   let password = req.body.password;
-  // console.log(username + " " + password);
+  console.log(username + " " + password);
   connection.query('SELECT * FROM users WHERE username = ?', [username],function (error, results, fields) {
     if (error) throw error;
     // console.log(results);


### PR DESCRIPTION
index.js: 
    - completely went back to original store setup, no need to use configureStore

MOST IMPORTANT CHANGE:
    - in the store, we are storing whether a user is logged in or not in a state called LoggedIn, either true or false
    - localStorage is now able to hold the token and user_id, they are set after logging in and removed after logging out (check the loginAction.js)
    - also in loginAction.js, you can see in the payloads there is an additional loggedIn with true/false parameter, this is then passed to reducer to update the store, which helps keep track of state of entire app
    - props should not be passed down components from app.js or anything, since the props are from state, you just import the appropriate states to that particular component/container and use the mapstatetoprops/matchdispatchtoprops and use connect to connect the component/container to store
    - I think everything that contains mapstatetoprops/matchdispatchtoprops and use connect belongs in containers, and component is as simple as possible, but this is just organization preference and we can figure things out later